### PR TITLE
add replacement for weforms shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ composer require boldgrid/bgforms
 
 ## Changelog ##
 
+### 1.2.1 ###
+* Update: Allow weforms shortcodes to have their form id replaced with the imported form id.
+
 ### 1.2.0 ###
 * New feature: Added support for weForms.
 


### PR DESCRIPTION
The issue I'm trying to resolve with what i'm doing right now, is that when a page is submitted via the author tool, the API server checks for specific shortcodes to determine whether or not to add that page revision to the 'install_plugin_scope' table.
Until now, '[weforms id=6]' was not in that list of shortcodes to check for. 

So, I added that to the list of shortcodes to check for. Now, it properly installs WeForms as expected.

However, the function that was replacing `[ninja_forms id="{api-ID}"]` with `[weforms id="{actual-ID}"]` needed to have a method to replace `[weforms id="{api-id"]` with `[weforms id="{actual-id}" ]`
So I had to add that to the `boldgrid/bgforms` library