### PR TITLE
Php8.2 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ composer require boldgrid/bgforms
 
 ## Changelog ##
 
+### 1.2.3 ###
+* Update: Fix PHP 8.2 Deprecation notices.
+
 ### 1.2.2 ###
 * Update: Use internal method to get_page_by_title() since WP6.2 deprecated the function.
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,13 @@
             "Boldgrid\\Library\\Form\\": "src/Form"
         }
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/boldgrid/library"
+        }
+    ],
     "require": {
-        "boldgrid/library": "^2.0.0"
+        "boldgrid/library": "dev-php8.2-fixes"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,13 +32,7 @@
             "Boldgrid\\Library\\Form\\": "src/Form"
         }
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/boldgrid/library"
-        }
-    ],
     "require": {
-        "boldgrid/library": "dev-php8.2-fixes"
+        "boldgrid/library": "^2.13.11"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,72 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "3a2f26c7a2e0805cd3b567c4a6341670",
+    "packages": [
+        {
+            "name": "boldgrid/library",
+            "version": "2.13.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/BoldGrid/library.git",
+                "reference": "ec1da4d4a6029968407b8f04c61417af4f5e4487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/BoldGrid/library/zipball/ec1da4d4a6029968407b8f04c61417af4f5e4487",
+                "reference": "ec1da4d4a6029968407b8f04c61417af4f5e4487",
+                "shasum": ""
+            },
+            "require-dev": {
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Boldgrid\\Library\\Util\\": "src/Util"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Elsass",
+                    "email": "dev@tim.ph",
+                    "homepage": "http://tim.ph",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Rafael Ramos",
+                    "homepage": "http://rafael-ramos.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Joe Cartonia",
+                    "email": "joec@boldgrid.com",
+                    "homepage": "https://twitter.com/joemotocss",
+                    "role": "Developer"
+                },
+                {
+                    "name": "bwmarkle",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The BoldGrid Library for shared code used in official BoldGrid plugins and themes.",
+            "time": "2023-05-23T20:04:34+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
+}


### PR DESCRIPTION
This resolves a handful of PHP8.2 Deprecated warnings. Mostly, it is resolving the following:
* Adding dynamic properties is deprecated
* strpos() argument 1 cannot be null